### PR TITLE
Add parcels layer and real wetlands data

### DIFF
--- a/components/LayerToggles.tsx
+++ b/components/LayerToggles.tsx
@@ -7,6 +7,7 @@ export type LayerState = {
   aadt: boolean;
   isd: boolean;
   wetlands: boolean;
+  parcels: boolean;
   centers: boolean;
   labels: boolean
 };
@@ -53,6 +54,10 @@ export default function LayerToggles({
         <label className="flex items-center gap-2 col-span-2">
           <input type="checkbox" checked={state.wetlands} onChange={() => flip('wetlands')} />
           Wetlands
+        </label>
+        <label className="flex items-center gap-2 col-span-2">
+          <input type="checkbox" checked={state.parcels} onChange={() => flip('parcels')} />
+          Parcels
         </label>
         <label className="flex items-center gap-2 col-span-2">
           <input type="checkbox" checked={state.centers} onChange={() => flip('centers')} />

--- a/pages/api/parcels.ts
+++ b/pages/api/parcels.ts
@@ -7,10 +7,10 @@ export default async function handler(req:NextApiRequest,res:NextApiResponse){
  try{
   const subj=String(req.query.subject||'TEHAMA');
   const [lon,lat]=SUBJECTS[subj]||SUBJECTS.TEHAMA;
-  const d=0.2;const bbox=[lon-d,lat-d,lon+d,lat+d];
-  const base='https://services.arcgis.com/QVENGdaPbd4LUkLV/ArcGIS/rest/services/Wetlands/FeatureServer/0/query';
+  const d=0.1;const bbox=[lon-d,lat-d,lon+d,lat+d];
+  const base='https://services2.arcgis.com/uXyoacYrZTPTKD3R/ArcGIS/rest/services/CCAD_Parcel_Feature_Set/FeatureServer/4/query';
   const p=new URLSearchParams({where:'1=1',outFields:'*',f:'geojson',outSR:'4326',geometry:bbox.join(','),geometryType:'esriGeometryEnvelope',inSR:'4326',spatialRel:'esriSpatialRelIntersects',resultRecordCount:'2000',resultOffset:'0'});
-  const features:any[]=[];let offset=0;while(true){p.set('resultOffset',String(offset));const r=await fetch(`${base}?${p.toString()}`);if(!r.ok) throw new Error(`wetlands ${r.status}`);const gj=await r.json();const batch=gj?.features??[];features.push(...batch);if(batch.length<2000) break;offset+=2000}
+  const features:any[]=[];let offset=0;while(true){p.set('resultOffset',String(offset));const r=await fetch(`${base}?${p.toString()}`);if(!r.ok) throw new Error(`parcels ${r.status}`);const gj=await r.json();const batch=gj?.features??[];features.push(...batch);if(batch.length<2000) break;offset+=2000}
   res.setHeader('Cache-Control','s-maxage=86400, stale-while-revalidate=86400');res.status(200).json({type:'FeatureCollection',features});
- }catch(e:any){console.error('wetlands:',e?.message||e);res.status(502).json({error:'Failed to fetch wetlands'})}
+ }catch(e:any){console.error('parcels:',e?.message||e);res.status(502).json({error:'Failed to fetch parcels'})}
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,6 +49,7 @@ export default function IndexPage() {
     aadt: true,
     isd: true,
     wetlands: false,
+    parcels: false,
     centers: true,
     labels: true // NEW: hybrid labels toggle
   });
@@ -60,6 +61,7 @@ export default function IndexPage() {
   const { data: aadt } = useSWR(`/api/aadt?year=2023`, fetcher);
   const { data: isd } = useSWR(`/api/isd`, fetcher);
   const { data: wet } = useSWR(`/api/wetlands?subject=${subjectId}`, fetcher);
+  const { data: parcels } = useSWR(`/api/parcels?subject=${subjectId}`, fetcher);
   const { data: centers } = useSWR(`/api/centers`, fetcher); // after `npm run geocode`
 
   // Background
@@ -237,6 +239,21 @@ export default function IndexPage() {
       );
     }
 
+    // Parcel boundaries
+    if (layersOn.parcels && parcels) {
+      L.push(
+        new GeoJsonLayer<any>({
+          id: 'parcels',
+          data: parcels as FC,
+          visible: viewState.zoom >= 15,
+          stroked: true,
+          filled: false,
+          getLineColor: [115, 76, 0, 200],
+          lineWidthMinPixels: 1
+        })
+      );
+    }
+
     // TLE centers
     if (layersOn.centers && centers) {
       L.push(
@@ -255,7 +272,7 @@ export default function IndexPage() {
     }
 
     return L;
-  }, [sim, aadt, isd, wet, centers, baseTiles, labelTiles, layersOn, viewState.zoom]);
+  }, [sim, aadt, isd, wet, parcels, centers, baseTiles, labelTiles, layersOn, viewState.zoom]);
 
   // ----- Actions -----
   async function runBatch() {


### PR DESCRIPTION
## Summary
- Load wetlands from USFWS service instead of returning an empty layer
- Add parcel layer with UI toggle, data fetch, and rendering
- Expose new `/api/parcels` endpoint backed by Collin CAD parcel service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a639ccd9c832ea0e8d3c87518afe2