### PR TITLE
Enable wetlands and parcel layers by default with zoom hints

### DIFF
--- a/components/LayerToggles.tsx
+++ b/components/LayerToggles.tsx
@@ -14,13 +14,17 @@ export type LayerState = {
 
 export default function LayerToggles({
   state,
-  setState
+  setState,
+  zoom
 }: {
   state: LayerState;
   setState: (s: LayerState) => void;
+  zoom: number;
 }) {
   const flip = (k: keyof LayerState) => setState({ ...state, [k]: !state[k] } as LayerState);
   const setBase = (b: 'satellite' | 'dark') => setState({ ...state, basemap: b });
+  const wetlandsReady = zoom >= 10;
+  const parcelsReady = zoom >= 15;
 
   return (
     <div className="bg-slate-900/90 text-white p-3 rounded-xl grid gap-2 w-[280px]">
@@ -51,13 +55,23 @@ export default function LayerToggles({
           <input type="checkbox" checked={state.isd} onChange={() => flip('isd')} />
           School districts
         </label>
-        <label className="flex items-center gap-2 col-span-2">
-          <input type="checkbox" checked={state.wetlands} onChange={() => flip('wetlands')} />
-          Wetlands
+        <label className="flex items-center gap-2 col-span-2" title="Visible at zoom ≥ 10">
+          <input
+            type="checkbox"
+            checked={state.wetlands}
+            onChange={() => flip('wetlands')}
+            disabled={!wetlandsReady}
+          />
+          Wetlands {!wetlandsReady && '(zoom ≥ 10)'}
         </label>
-        <label className="flex items-center gap-2 col-span-2">
-          <input type="checkbox" checked={state.parcels} onChange={() => flip('parcels')} />
-          Parcels
+        <label className="flex items-center gap-2 col-span-2" title="Visible at zoom ≥ 15">
+          <input
+            type="checkbox"
+            checked={state.parcels}
+            onChange={() => flip('parcels')}
+            disabled={!parcelsReady}
+          />
+          Parcels {!parcelsReady && '(zoom ≥ 15)'}
         </label>
         <label className="flex items-center gap-2 col-span-2">
           <input type="checkbox" checked={state.centers} onChange={() => flip('centers')} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,8 +48,8 @@ export default function IndexPage() {
     arcs: false,
     aadt: true,
     isd: true,
-    wetlands: false,
-    parcels: false,
+    wetlands: true,
+    parcels: true,
     centers: true,
     labels: true // NEW: hybrid labels toggle
   });
@@ -390,7 +390,11 @@ export default function IndexPage() {
       {/* Left tools */}
       <div className="absolute left-3 bottom-3 flex flex-col gap-3">
         <WeightsPanel w={weights} setW={setWeights} />
-        <LayerToggles state={layersOn as LayerState & { labels: boolean }} setState={setLayersOn as any} />
+        <LayerToggles
+          state={layersOn as LayerState & { labels: boolean }}
+          setState={setLayersOn as any}
+          zoom={viewState.zoom}
+        />
         <CameraBar onTopDown={snapTopDownNorth} onIso={snapIsometric} onReset={resetToSubject} onFit={fitNeighbors} />
       </div>
 


### PR DESCRIPTION
## Summary
- Turn on wetlands and parcel layers by default
- Add zoom-aware tooltips and disabled states for wetlands and parcel checkboxes
- Pass current zoom level to LayerToggles so UI can guide users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a6894ffe4832eb313d9e31166b622