### PR TITLE
Add labels overlay toggle in layer controls

### DIFF
--- a/components/LayerToggles.tsx
+++ b/components/LayerToggles.tsx
@@ -63,6 +63,10 @@ export default function LayerToggles({
           <input type="checkbox" checked={state.centers} onChange={() => flip('centers')} />
           TLE centers
         </label>
+        <label className="flex items-center gap-2 col-span-2">
+          <input type="checkbox" checked={state.labels} onChange={() => flip('labels')} />
+          Labels overlay
+        </label>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a checkbox to LayerToggles for toggling the labels overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a6896c1e0832eab80da201c1c5c9d